### PR TITLE
Update PHP Versions Used In Package Requirements and For Testing Against

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.4', '8.0', '8.1']
     name: Test with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.4||^8.0",
         "phpseclib/phpseclib": "^2.0",
         "ext-bcmath": "*"
     },


### PR DESCRIPTION
This change updates our `composer.json` file so we now require versions of PHP which are supported by PHP themselves. This also updates the GitHub Actions workflow file so we're testing against those same supported versions.